### PR TITLE
Ensure the secret is an integer before calling the SOAP driver.

### DIFF
--- a/lib/puppet/parser/functions/thycotic.rb
+++ b/lib/puppet/parser/functions/thycotic.rb
@@ -288,7 +288,7 @@ class Thycotic
     begin
       params = {
         :token    => getToken(),
-        :secretId => secretid,
+        :secretId => secretid.to_i,
       }
       resp = getDriver().GetSecret(params)
 


### PR DESCRIPTION
@siminm , review?