### PR TITLE
Set the connect/receive/send timeouts for the Secret Server HTTP object.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
 rvm:
- - 1.8.7
  - 1.9.3
  - 2.0.0

--- a/lib/puppet/parser/functions/thycotic.rb
+++ b/lib/puppet/parser/functions/thycotic.rb
@@ -540,6 +540,12 @@ class Thycotic
     max_tries = 3
     begin
       @driver = SOAP::WSDLDriverFactory.new(@params[:serviceurl]).create_rpc_driver
+
+      # Increase the timeout on the http module when making calls to the secret server
+      @driver.options["protocol.http.connect_timeout"] =  60 # [sec]
+      @driver.options["protocol.http.send_timeout"]    = 120 # [sec]
+      @driver.options["protocol.http.receive_timeout"] =  60 # [sec]
+
       return @driver
     rescue Exception=>e
       log("Could not create SOAP Driver from URL #{@params[:serviceurl]}: #{e}")

--- a/spec/functions/getsecret_spec.rb
+++ b/spec/functions/getsecret_spec.rb
@@ -11,20 +11,9 @@ describe 'getsecret' do
     Puppet::Parser::Functions.function("getsecret").should == "function_getsecret"
   end
 
-  it 'should require at least two variables' do
-    expect {
-      should run.with_params().and_return(0)
-    }.to raise_error(Puppet::ParseError) 
-    expect {
-      should run.with_params('x').and_return(0)
-    }.to raise_error(Puppet::ParseError) 
-  end
-
-  it 'suppying a bogus config file should fail' do
-   expect {
-     should run.with_params(123,'name', '/path/to/bogus/config').and_return(0)
-   }.to raise_error(Puppet::ParseError)
-  end
+  it {is_expected.to run.with_params().and_raise_error(Puppet::ParseError)}
+  it {is_expected.to run.with_params('x').and_raise_error(Puppet::ParseError)}
+  it {is_expected.to run.with_params(123,'name', '/path/to/bogus/config').and_raise_error(Puppet::ParseError)}
 end
 
 describe 'thycotic_getsecret' do


### PR DESCRIPTION
@siminm, @nrvale0 -- I am testing this out on our EU puppet servers now to see if this will stem the flow of the errors we were seeing.