### PR TITLE
Change - Update possible configuration paths to use new puppet4 path

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The configuration file can be located in three places by default. It is searched
 for in the following order:
 
 - ${thycotic_configpath}/thycotic.conf
+- /etc/puppetlabs/puppet/thycotic.conf
 - /etc/puppet/thycotic.conf
 - <path to module>/lib/puppet/parser/functions/thycotic.conf
 

--- a/lib/puppet/parser/functions/getsecret.rb
+++ b/lib/puppet/parser/functions/getsecret.rb
@@ -65,6 +65,7 @@ def init(custom_config=nil)
   # file instead.
   possible_paths = [
     "#{lookupvar('thycotic_configpath')}/thycotic.conf",
+    "/etc/puppetlabs/puppet/thycotic.conf",
     "/etc/puppet/thycotic.conf",
     File.join(File.dirname(__FILE__), 'thycotic.conf') ]
 


### PR DESCRIPTION
Puppet has changed puppet paths to use the /etc/puppetlabs/puppet directory in the puppet 4 release.